### PR TITLE
Automatically draft release through AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.2.{build}
 branches:
   only:
     - master
+    - /\d+\.\d+\.\d+/
 
 environment:
   global:
@@ -98,10 +99,10 @@ for:
 
     artifacts:
       - path: bin/release
-        name: UltraStar-Creator-portable
+        name: WIN64-UltraStar-Creator-portable
         type: zip
-      - path: bin/UltraStar-Creator*-setup.exe
-        name: UltraStar-Creator-installer
+      - path: bin/WIN64-UltraStar-Creator*-setup.exe
+        name: WIN64-UltraStar-Creator-installer
 
     on_failure:
       # Change false to true to block build and investigate build failures
@@ -133,15 +134,16 @@ for:
       - /usr/local/opt/qt/bin/qmake6 UltraStar-Creator.pro
       - make -j$(getconf _NPROCESSORS_ONLN)
       - cd ../bin/release
+      - mv UltraStar-Creator.dmg MAC-UltraStar-Creator.dmg
       - ls
       #- macdeployqt UltraStar-Creator.app -dmg;
 
     artifacts:
       - path: bin/release
-        name: UltraStar-Creator portable
+        name: MAC-UltraStar-Creator-portable
         type: zip
-      - path: bin/release/UltraStar-Creator.dmg
-        name: UltraStar-Creator disk image
+      - path: bin/release/MAC-UltraStar-Creator.dmg
+        name: MAC-UltraStar-Creator-image
 
   # Ubuntu (AppImage)
   -
@@ -183,13 +185,25 @@ for:
       - sh: unset LD_LIBRARY_PATH
       - sh: cp ../../setup/unix/UltraStar-Creator.desktop .
       - sh: cp ../../setup/unix/UltraStar-Creator.png .
+      - sh: sed -i "s/Name=UltraStar-Creator/Name=LINUX-UltraStar-Creator/g" UltraStar-Creator.desktop 
       - sh: ./linuxdeployqt*.AppImage UltraStar-Creator.desktop -bundle-non-qt-libs -appimage
 
     artifacts:
-      - path: bin/release/UltraStar-Creator-*.AppImage
-        name: UltraStar-Creator AppImage Package
+      - path: bin/release/LINUX-UltraStar-Creator-*.AppImage
+        name: LINUX-UltraStar-Creator-appimage
         
     on_failure:
       # Change false to true to block build and investigate build failures
       - sh: export APPVEYOR_SSH_BLOCK=true
       - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+
+deploy:
+  description: ''
+  provider: GitHub
+  draft: true
+  auth_token:
+    secure: ykwnM89TZTiQ/nmI5ijPtlekJ3BgzaT37M/hYeMNYnUvPO1U+JoYIWLXjHcZCSyL
+  artifact: WIN64-UltraStar-Creator-portable,WIN64-UltraStar-Creator-installer,MAC-UltraStar-Creator-portable,MAC-UltraStar-Creator-image,LINUX-UltraStar-Creator-appimage
+  on:
+    # deploy on tag push only
+    APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -202,7 +202,7 @@ deploy:
   provider: GitHub
   draft: true
   auth_token:
-    secure: ykwnM89TZTiQ/nmI5ijPtlekJ3BgzaT37M/hYeMNYnUvPO1U+JoYIWLXjHcZCSyL
+    secure: KM1pcikmRxD8Sm3b/KQK2qB+tnHMoo718HELocKPpCwuaE349q7poSMzA3kmvcVU
   artifact: WIN64-UltraStar-Creator-portable,WIN64-UltraStar-Creator-installer,MAC-UltraStar-Creator-portable,MAC-UltraStar-Creator-image,LINUX-UltraStar-Creator-appimage
   on:
     # deploy on tag push only

--- a/setup/win64/UltraStar-Creator.nsi
+++ b/setup/win64/UltraStar-Creator.nsi
@@ -17,7 +17,7 @@ Name "${PRODUCTNAME} ${PRODUCTVERSION}"
 !define BASE_REGKEY "Software\HPI\${PRODUCTNAME}"
 !define UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
 
-OutFile "..\UltraStar-Creator-${PRODUCTVERSION}-win64-setup.exe"
+OutFile "..\WIN64-UltraStar-Creator-${PRODUCTVERSION}-setup.exe"
 InstallDir "$PROGRAMFILES\${PRODUCTNAME}"
 InstallDirRegKey HKCU "Software\HPI\${PRODUCTNAME}" ""
 


### PR DESCRIPTION
This drafts a release containing the build artifacts whenever a tag of the form x.y.z is pushed.
An example for a release created this way can be seen [here](https://github.com/DeinAlptraum/UltraStar-Creator/releases/tag/1.0.0).

In order to make the artifact names for the different platforms easily distinguishable, I've renamed them, mostly prepending them with a platform name (WIN64, MAC, LINUX)

I've decided to go with drafts because I don't see a nice way to add a description for the release without editing it directly on Github. This means the workflow is something like
1. Create tag locally
2. Push tag
3. Wait for CI to create a draft release, build and then add the artifacts automatically
4. Add release notes to draft manually
5. Release

Does this implement what you imagined?

Note that tags always start a build and I don't see a way to change this, e.g. if you make a commit locally, give it a release tag and then push both, the commit will essentially be built twice: once for the commit itself, and once for the release tag.