### PR TITLE
Fix AppVeyor Build and Windows installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     # Windows
     - ARCH: x64
       COMPILER: msvc2019 #MinGW
-      QTDIR: C:\Qt\6.5.1\msvc2019_64 #C:\Qt\6.5.0\mingw_64
+      QTDIR: C:\Qt\6.5\msvc2019_64 #C:\Qt\6.5.0\mingw_64
     # macOS
     - ARCH: x64
       COMPILER: Clang
@@ -72,7 +72,7 @@ for:
 
     build_script:
       # build taglib
-      - git clone https://github.com/taglib/taglib.git 
+      - git clone --recurse-submodules https://github.com/taglib/taglib.git 
       - cd .\taglib
       - mkdir build
       - cd build

--- a/setup/win64/UltraStar-Creator.nsi
+++ b/setup/win64/UltraStar-Creator.nsi
@@ -108,6 +108,8 @@ Section "Application" SecCopyUI
 	File "tls\qcertonlybackend.dll" ;; needed?
 	File "tls\qopensslbackend.dll" ;; needed?
 	File "tls\qschannelbackend.dll" ;; needed?
+	SetOutPath "C:\Program Files\taglib\lib"
+	File "tag.dll"
 
 	;; setup initial reg values
 	;; WriteRegStr HKCU "Software\HPI\${PRODUCTNAME}" "key" "value1 value2"

--- a/src/UltraStar-Creator.pro
+++ b/src/UltraStar-Creator.pro
@@ -168,10 +168,11 @@ win32 {
 	QMAKE_POST_LINK += $${QMAKE_DEL_FILE} $$shell_path($${DESTDIR}/imageformats/qwbmp*.dll) $$escape_expand(\\n\\t)
 	QMAKE_POST_LINK += $${QMAKE_DEL_FILE} $$shell_path($${DESTDIR}/imageformats/qwebp*.dll) $$escape_expand(\\n\\t)
 
-	# Manually add bass, bass_fx and libcld2 libraries
+	# Manually add bass, bass_fx, libcld2 and taglib libraries
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path(../lib/win64/bass.dll) $$shell_path($${DESTDIR}) $$escape_expand(\\n\\t)
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path(../lib/win64/bass_fx.dll) $$shell_path($${DESTDIR}) $$escape_expand(\\n\\t)
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path(../lib/win64/cld2.dll) $$shell_path($${DESTDIR}) $$escape_expand(\\n\\t)
+ 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path(../taglib/build/taglib/Release/tag.dll) $$shell_path($${DESTDIR}) $$escape_expand(\\n\\t)
 
 	# Copy SSL/TLS libraries
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path(../lib/win64/capi.dll) $$shell_path($${DESTDIR}) $$escape_expand(\\n\\t)


### PR DESCRIPTION
Include tag.dll in Windows installer and copy it to the right location on install.

Fix taglib build in AppVeyor by including submodules.
Fix QT version for Windows builds