### PR TITLE
CI: Update Qt version for Linux build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
     # Ubuntu
     - ARCH: x64
       COMPILER: GCC
-      QTDIR: Qt/6.4/gcc_64
+      QTDIR: Qt/6.5/gcc_64
 
 image:
   # AppVeyor builds are ordered by the image list:


### PR DESCRIPTION
AppVeyor stopped offering Qt 6.4 on their Ubuntu image