### PR TITLE
CI: fix Windows deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Set up MSVC Environment
-        uses: seanmiddleditch/gha-setup-vsdevenv@master
+        uses: compnerd/gha-setup-vsdevenv@main
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Install Qt


### PR DESCRIPTION
The original vsdevenv action seems to be unmaintained, this PR switches to a fork of it containing updates that fix the warnings we are currently getting.