### PR TITLE
Windows: install taglib in app folder instead of globally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           cd taglib
           cmake -B build -G "Visual Studio 17 2022" -A x64 -DWITH_ZLIB=OFF -DBUILD_SHARED_LIBS=ON -DENABLE_STATIC_RUNTIME=OFF -DBUILD_TESTING=OFF
           msbuild build/install.vcxproj -p:Configuration=Release
+          cp -r "C:/Program Files/taglib/include/taglib" ../include
+          copy build/taglib/Release/tag.dll ../lib/win64
+          copy build/taglib/Release/tag.lib ../lib/win64
       - name: Install cld2
         run: |
           git clone https://github.com/CLD2Owners/cld2.git

--- a/setup/win64/UltraStar-Creator.nsi
+++ b/setup/win64/UltraStar-Creator.nsi
@@ -65,6 +65,7 @@ Section "Application" SecCopyUI
 	File "capi.dll"
 	File "changes.txt"
 	File "cld2.dll"
+	File "tag.dll"
 	File "dasync.dll"
 	File "English.txt"
 	File "French.txt"
@@ -108,8 +109,6 @@ Section "Application" SecCopyUI
 	File "tls\qcertonlybackend.dll" ;; needed?
 	File "tls\qopensslbackend.dll" ;; needed?
 	File "tls\qschannelbackend.dll" ;; needed?
-	SetOutPath "C:\Program Files\taglib\lib"
-	File "tag.dll"
 
 	;; setup initial reg values
 	;; WriteRegStr HKCU "Software\HPI\${PRODUCTNAME}" "key" "value1 value2"
@@ -170,6 +169,7 @@ Section "Uninstall"
 	
 	Delete "$INSTDIR\bass.dll"
 	Delete "$INSTDIR\bass_fx.dll"
+	Delete "$INSTDIR\tag.dll"
 	Delete "$INSTDIR\changes.txt"
 	Delete "$INSTDIR\libgcc_s_seh-1.dll"
 	Delete "$INSTDIR\libstdc++-6.dll"

--- a/src/UltraStar-Creator.pro
+++ b/src/UltraStar-Creator.pro
@@ -77,14 +77,13 @@ INCLUDEPATH += ../include/bass \
 	../include/srtparser
 
 win32 {
-	INCLUDEPATH += "C:/Program Files/taglib/include/taglib"
+	INCLUDEPATH += ../include/taglib
 
-	LIBS += -L"C:/Program Files/taglib/lib" \
-		-ltag
 	LIBS += -L"../lib/win64" \
 		-lbass \
 		-lbass_fx \
-		-lcld2
+		-lcld2 \
+		-ltag
 
 	RC_ICONS += UltraStar-Creator.ico
 }


### PR DESCRIPTION
USC currently installs taglib on Windows, hardcoded to `C:\Program Files\taglib\lib`. This is problematic when
a) upgrading from an older version that still had a local taglib in the appfolder, which might use the outdated version and lead to crashes
b) is generally bad design for when the user does not want you to install stuff to their Program Files without asking, when they don't have a C drive etc. and also prevents us from removing taglib again when we uninstall

This PR changes the behavior to install taglib locally again, into the USC app folder.
The only downside of this approach is, that a user trying to compile USC on Windows would have to specifically place taglib into the top-level USC repo folder for linking to succeed