### PR TITLE
Add Spanish (Latino) and Portuguese (Brazil) as song languages

### DIFF
--- a/src/QUMainWindow.cpp
+++ b/src/QUMainWindow.cpp
@@ -153,10 +153,12 @@ void QUMainWindow::initWindow() {
 	ui->comboBox_Language->addItem(QIcon(":/languages/no.png"),tr("Norwegian"),"Norwegian");
 	ui->comboBox_Language->addItem(QIcon(":/languages/pl.png"),tr("Polish"),"Polish");
 	ui->comboBox_Language->addItem(QIcon(":/languages/pt.png"),tr("Portuguese"),"Portuguese");
+	ui->comboBox_Language->addItem(QIcon(":/languages/pt.png"),tr("Portuguese (Brazil)"),"Portuguese (Brazil)");
 	ui->comboBox_Language->addItem(QIcon(":/languages/ru.png"),tr("Russian"),"Russian");
 	ui->comboBox_Language->addItem(QIcon(":/languages/sk.png"),tr("Slovak"),"Slovak");
 	ui->comboBox_Language->addItem(QIcon(":/languages/si.png"),tr("Slowenian"),"Slowenian");
 	ui->comboBox_Language->addItem(QIcon(":/languages/es.png"),tr("Spanish"),"Spanish");
+	ui->comboBox_Language->addItem(QIcon(":/languages/es.png"),tr("Spanish (Latino)"),"Spanish (Latino)");
 	ui->comboBox_Language->addItem(QIcon(":/languages/se.png"),tr("Swedish"),"Swedish");
 	ui->comboBox_Language->addItem(QIcon(":/languages/tr.png"),tr("Turkish"),"Turkish");
 	ui->comboBox_Language->addItem(QIcon(":/languages/wales.png"),tr("Welsh"),"Welsh");

--- a/src/QUSongSupport.cpp
+++ b/src/QUSongSupport.cpp
@@ -125,11 +125,13 @@ QStringList QUSongSupport::availableSongLanguages() {
 	result << "Norwegian";
 	result << "Polish";
 	result << "Portuguese";
+	result << "Portuguese (Brazil)";
 	result << "Romanian";
 	result << "Russian";
 	result << "Slovak";
 	result << "Slowenian";
 	result << "Spanish";
+	result << "Spanish (Latino)";
 	result << "Swedish";
 	result << "Turkish";
 


### PR DESCRIPTION
This currently uses the same flags for each language and its variants. At least for Portuguese (Brazil) it might be reasonable to add a flag at some point.

The language naming was taken from usdb: there are mutliple results with Portuguese (Brazil), and exactly one with Spanish (Latino)