### PR TITLE
Simplify build instructions and update README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,13 +90,10 @@ jobs:
           brew install qt
       - name: Install cld2
         run: |
-          cd include/cld2/internal/
+          cd include
+          patch cld2/internal/compile_libs.sh cld2-mac-compile.patch
+          cd cld2/internal/
           export CFLAGS="-Wno-narrowing -O3"
-          sed -i '' "s/soname=/install_name,/g" compile_libs.sh
-          sed -i '' "s/-shared/-dynamiclib/g" compile_libs.sh
-          sed -i '' "s/libcld2.so/libcld2.dylib/g" compile_libs.sh
-          sed -i '' "s/libcld2_full.so/libcld2_full.dylib/g" compile_libs.sh
-          cat compile_libs.sh
           ./compile_libs.sh
           cp libcld2.dylib ../../../lib/macx
       - name: Fix Qt lib rpaths # see: https://github.com/orgs/Homebrew/discussions/2823#discussioncomment-2010340)

--- a/README.md
+++ b/README.md
@@ -19,37 +19,63 @@ UltraStar-Creator (usc) is a free and open source song creation tool using Qt. I
 (under construction)
 
 ### 5. Build and Run
-#### Compiling on Windows
-(under construction)
+#### Compiling on Windows (MSVC)
 
-1. Install Qt6.
-2. Build UltraStar-Creator
-   * from command line: `cd src && qmake UltraStar-Creator.pro && make` 
+Note: you might have to setup the MSVC commandline environment before building.
+1. Install Qt6. We recommend Qt 6.5
+2. Build taglib. From command line (in repository root):
+```
+git clone --recurse-submodules https://github.com/taglib/taglib.git
+cd taglib
+cmake -B build -G "Visual Studio 17 2022" -A x64 -DWITH_ZLIB=OFF -DBUILD_SHARED_LIBS=ON -DENABLE_STATIC_RUNTIME=OFF -DBUILD_TESTING=OFF
+msbuild build/install.vcxproj -p:Configuration=Release
+cp -r "C:/Program Files/taglib/include/taglib" ../include
+copy build/taglib/Release/tag.dll ../lib/win64
+copy build/taglib/Release/tag.lib ../lib/win64
+```
+3. Build cld2. Make sure you cloned with submodules included. From command line (in repository root):
+```
+cd include/cld2/internal
+cl /TP /GR /EHsc /c /MD cldutil.cc cldutil_shared.cc compact_lang_det.cc compact_lang_det_hint_code.cc compact_lang_det_impl.cc  debug.cc fixunicodevalue.cc generated_entities.cc  generated_language.cc generated_ulscript.cc getonescriptspan.cc lang_script.cc offsetmap.cc  scoreonescriptspan.cc tote.cc utf8statetable.cc cld_generated_cjk_uni_prop_80.cc cld2_generated_cjk_compatible.cc cld_generated_cjk_delta_bi_32.cc generated_distinct_bi_0.cc cld2_generated_quad0122.cc cld2_generated_deltaocta0122.cc cld2_generated_distinctocta0122.cc cld_generated_score_quad_octa_0122.cc
+link /dll /out:cld2.dll *.obj
+lib /out:cld2.lib *.obj
+copy .\cld2.lib ..\..\..\lib\win64
+copy .\cld2.dll ..\..\..\lib\win64
+```
+4. Build UltraStar-Creator
+   * from command line: `cd src && qmake6 UltraStar-Creator.pro -spec win32-msvc && nmake` 
    * using Qt Creator: open `src\UltraStar-Creator.pro` in Qt Creator, disable shadow build in Project tab, then build (CTRL+B)
-3. Run `UltraStar-Creator.exe` in `bin\releease` and start creating new songs!
+5. Run `UltraStar-Creator.exe` in `bin\releease` and start creating new songs!
 
 #### Compiling on Linux
-(under construction)
+These are example instructions for Ubuntu. Package names may have to be adapted for your distribution.
 
-1. Install Qt6.
-2. Install dependencies: `sudo apt-get install libtag1-dev`
-3. `git clone https://github.com/UltraStar-Deluxe/UltraStar-Creator.git`
-4. `cd UltraStar-Creator`
-5. Build UltraStar-Creator
-   * from command line: `cd src && qmake6 UltraStar-Creator.pro && make` 
+1. Install Qt6. We recommend Qt 6.5
+2. Install dependencies: `sudo apt-get install libgl1-mesa-dev build-essential libtag1-dev libcld2-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb-dev libxkbcommon-x11-0 libxcb-cursor0 libgtk2.0-dev libfuse2`
+3. Build UltraStar-Creator. From repository root:
+   * via command line (from repository root): `cd src && qmake6 UltraStar-Creator.pro && make` 
    * using Qt Creator: open `src/UltraStar-Creator.pro` in Qt Creator, disable shadow build in Project tab, then build (CTRL+B)
-6. Run `UltraStar-Creator` in `bin/release` and start creating new songs!
+4. Run `UltraStar-Creator` in `bin/release` and start creating new songs!
 
 #### Compiling on Mac OS X
-(under construction)
+We support both x86 (Intel) and ARM (M1/M2) Macs.
 
 1. Install homebrew via `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 2. Install the Qt framework via `brew install qt`.
 3. Install external dependencies via `brew install taglib`
-4. Build UltraStar-Creator
+4. Build cld2. Make sure you cloned with submodules included. From command line (in repository root):
+```
+cd include
+patch cld2/internal/compile_libs.sh cld2-mac-compile.patch
+cd cld2/internal/
+export CFLAGS="-Wno-narrowing -O3"
+./compile_libs.sh
+cp libcld2.dylib ../../../lib/macx
+```
+5. Build UltraStar-Creator
    * from command line: `cd src && qmake UltraStar-Creator.pro && make` 
    * using Qt Creator: open `src/UltraStar-Creator.pro` in Qt Creator, disable shadow build in Project tab, then build (CTRL+B)
-5. Run `UltraStar-Creator.app` in `bin/release` and start creating new songs!
+6. Run `UltraStar-Creator.app` in `bin/release` and start creating new songs!
 
 ### 6. Contribute
 Feel free to fork this project, modify it to your hearts content and maybe also do pull requests to this repository for additional features, improvements or clean-ups.

--- a/include/cld2-mac-compile.patch
+++ b/include/cld2-mac-compile.patch
@@ -1,0 +1,31 @@
+diff --git a/internal/compile_libs.sh b/internal/compile_libs.sh
+index 38c6655..49a6a7e 100755
+--- a/internal/compile_libs.sh
++++ b/internal/compile_libs.sh
+@@ -27,7 +27,7 @@ if [ -n "${CPPFLAGS}" ]; then
+   echo "CPPFLAGS=${CPPFLAGS}"
+ fi
+ 
+-g++ $CFLAGS $CPPFLAGS $CXXFLAGS -shared -fPIC \
++g++ $CFLAGS $CPPFLAGS $CXXFLAGS -dynamiclib -fPIC \
+   cldutil.cc cldutil_shared.cc compact_lang_det.cc compact_lang_det_hint_code.cc \
+   compact_lang_det_impl.cc  debug.cc fixunicodevalue.cc \
+   generated_entities.cc  generated_language.cc generated_ulscript.cc  \
+@@ -37,17 +37,5 @@ g++ $CFLAGS $CPPFLAGS $CXXFLAGS -shared -fPIC \
+   cld_generated_cjk_delta_bi_4.cc generated_distinct_bi_0.cc  \
+   cld2_generated_quadchrome_2.cc cld2_generated_deltaoctachrome.cc \
+   cld2_generated_distinctoctachrome.cc  cld_generated_score_quad_octa_2.cc  \
+-  -o libcld2.so $LDFLAGS -Wl,-soname=libcld2.so
+-
+-g++ $CFLAGS $CPPFLAGS $CXXFLAGS -shared -fPIC \
+-  cldutil.cc cldutil_shared.cc compact_lang_det.cc compact_lang_det_hint_code.cc \
+-  compact_lang_det_impl.cc  debug.cc fixunicodevalue.cc \
+-  generated_entities.cc  generated_language.cc generated_ulscript.cc  \
+-  getonescriptspan.cc lang_script.cc offsetmap.cc  scoreonescriptspan.cc \
+-  tote.cc utf8statetable.cc  \
+-  cld_generated_cjk_uni_prop_80.cc cld2_generated_cjk_compatible.cc  \
+-  cld_generated_cjk_delta_bi_32.cc generated_distinct_bi_0.cc  \
+-  cld2_generated_quad0122.cc cld2_generated_deltaocta0122.cc \
+-  cld2_generated_distinctocta0122.cc  cld_generated_score_quad_octa_0122.cc  \
+-  -o libcld2_full.so $LDFLAGS -Wl,-soname=libcld2_full.so
++  -o libcld2.dylib $LDFLAGS -Wl,-install_name,libcld2.dylib


### PR DESCRIPTION
This updates the build instructions in the README. They should be correct as they're taken from the Github Actions workflow, but might be missing some of the details, including environment setup on Windows. 

I also collected all the `sed` commands for the cld2 build script adaption on Mac into a proper patch file for slightly better usability, and excluded the `libcld2_full.dylib` from the Mac build since we don't use it.

This resolves #41 